### PR TITLE
ci: install targets for pinned toolchain; ensure cross available

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,17 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      # rust-toolchain.toml の pinned 版(1.89.0)に対してターゲットを導入
+      - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
-          target: ${{ matrix.target }}
+          # toolchain は rust-toolchain.toml に委譲（未指定で自動検出）
+          targets: ${{ matrix.target }}
+          components: rustfmt, clippy
+      # cross を明示的に導入（Linuxでのクロスコンパイル、他OSではcargoにフォールバック）
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cross
       - uses: actions-rs/cargo@v1
         with:
           use-cross: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       # rust-toolchain.toml の pinned 版(1.89.0)に対してターゲットを導入
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@1.89.0
         with:
           # toolchain は rust-toolchain.toml に委譲（未指定で自動検出）
           targets: ${{ matrix.target }}
@@ -45,11 +45,10 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cross
-      - uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: build
-          args: --release --target ${{ matrix.target }}
+      - name: Build (cross)
+        shell: bash
+        run: |
+          cross build --release --target ${{ matrix.target }}
 
       - uses: cli/gh-extension-precompile@v1
         with:


### PR DESCRIPTION
原因\n-  で 1.89.0 に固定後も、CI は  で  に対してのみ target を追加していました。\n- ビルド実行時は pinned ツールチェイン (1.89.0) が有効になるため、該当ツールチェイン側に target が入らず、（= target未導入）が発生。\n\n対応\n-  を  に置き換え、 に従うツールチェインへ  を導入。\n-  で  を導入（Linuxでのクロスビルド、macOS/Windowsでは cargo へフォールバック）。\n\n期待\n- macOS の  など、全 matrix で target が適切に導入され、エラーが解消されます。